### PR TITLE
Add class diagrams to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,68 @@ This document provides an overview of the REST API services available in the E-c
 #### Lifecycle Callbacks:
 - `@PrePersist`: Initializes `createdAt` and `updatedAt` timestamps.
 - `@PreUpdate`: Updates the `updatedAt` timestamp.
+
+## LLD Class Diagrams
+
+```mermaid
+classDiagram
+    class User {
+        Long id
+        String email
+        String password
+        String firstName
+        String lastName
+        Set<String> roles
+        LocalDateTime createdAt
+        LocalDateTime updatedAt
+    }
+
+    class Order {
+        Long id
+        BigDecimal totalAmount
+        OrderStatus status
+        Long userId
+        List<OrderItem> orderItems
+        LocalDateTime createdAt
+        LocalDateTime updatedAt
+    }
+
+    class OrderItem {
+        Long id
+        Order order
+        Product product
+        Integer quantity
+        BigDecimal unitPrice
+        BigDecimal subtotal
+        LocalDateTime createdAt
+        LocalDateTime updatedAt
+    }
+
+    class Product {
+        Long id
+        String name
+        String description
+        BigDecimal price
+        Integer stockQuantity
+        LocalDateTime createdAt
+        LocalDateTime updatedAt
+    }
+
+    class Payment {
+        Long id
+        String transactionId
+        BigDecimal amount
+        PaymentStatus status
+        PaymentMethod paymentMethod
+        Long orderId
+        LocalDateTime paymentDate
+        String failureReason
+        LocalDateTime createdAt
+        LocalDateTime updatedAt
+    }
+
+    User "1" --> "0..*" Order : places
+    Order "1" --> "0..*" OrderItem : contains
+    OrderItem "1" --> "1" Product : refers to
+    Order "1" --> "0..*" Payment : has
+```


### PR DESCRIPTION
Add LLD class diagrams to the `README.md` file.

* Add a new section titled "LLD Class Diagrams" after the "Models" section.
* Include a single class diagram showing all relationships between `User`, `Order`, `OrderItem`, `Product`, and `Payment` services using Mermaid syntax.
* Remove the sections for "Current Monolithic Architecture" and "Proposed Microservices Architecture".

